### PR TITLE
Update CLI tests for fapi branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,128 @@ The key features are:
 \* estimation based on tests on an internal development team, building
 production applications.
 
+## Modular application patterns
+
+FAPI includes a Flask-style extension protocol, blueprint-style modules, a
+lightweight event bus, context locals, and a unified configuration registry.
+These features encourage factory-based application construction and reusable
+capability bundles.
+
+### Extensions
+
+Extensions contribute routers, middleware, dependencies, config defaults, tool
+metadata, lifecycle hooks, and CLI commands.
+
+```python
+from fapi import Extension, FastAPI
+
+
+class AnalyticsExtension(Extension):
+    def config_defaults(self) -> dict[str, str]:
+        return {"api_key": "change-me"}
+
+    def cli_commands(self):
+        def show_status() -> None:
+            print("Analytics extension ready")
+
+        return [show_status]
+
+
+app = FastAPI(extensions=[AnalyticsExtension()])
+```
+
+### Modules
+
+Modules collect routers, middleware, config defaults, and tool schemas that are
+applied when attached to an app.
+
+```python
+from fapi import Module, FastAPI
+from fapi.routing import APIRouter
+
+module = Module("billing", prefix="/billing", tags=["billing"])
+router = APIRouter()
+
+
+@router.get("/status")
+def status() -> dict[str, str]:
+    return {"state": "ok"}
+
+
+module.add_router(router)
+
+app = FastAPI()
+app.register_module(module)
+```
+
+### Context locals
+
+Enable context locals to access the current application, request, and a per-
+request scratch dictionary.
+
+```python
+from fapi import FastAPI, current_app, g
+
+app = FastAPI(use_context_locals=True)
+
+
+@app.get("/whoami")
+def whoami() -> dict[str, str]:
+    g["visited"] = True
+    return {"app": current_app.title}
+```
+
+### Configuration
+
+The configuration registry merges defaults, environment variables, and instance
+folders. Extensions and modules can register defaults using namespaces.
+
+```python
+from fapi import FastAPI
+
+app = FastAPI(config={"log_level": "info"})
+app.config.load_defaults({"enabled": True}, namespace="auth")
+```
+
+Tool metadata schemas should follow this structure:
+
+```python
+{
+    "name": "my_tool",
+    "version": "1.0",
+    "description": "Describe the tool",
+    "input_schema": {"type": "object"},
+    "output_schema": {"type": "object"},
+}
+```
+
+For streaming endpoints, wrap iterables with `fapi.events.stream_with_events`
+to emit tool lifecycle events.
+
+### CLI
+
+The Typer-based CLI provides common commands and supports extension and module
+subcommands.
+
+```bash
+fapi run --host 127.0.0.1 --port 8000
+fapi list-tools
+fapi show-config
+```
+
+The CLI uses the `create_app` factory. Use `uvicorn module:app` when you want
+to run an explicit application object.
+
+### Factory pattern
+
+Use the factory helper to assemble apps with extensions and modules.
+
+```python
+from fapi import Extension, Module, create_app
+
+app = create_app(extensions=[Extension()], modules=[Module("core")])
+```
+
 ## Complete Development Setup Guide
 
 This section provides step-by-step instructions for setting up a complete

--- a/examples/extension_with_cli.py
+++ b/examples/extension_with_cli.py
@@ -1,0 +1,18 @@
+"""Example extension that registers a CLI command."""
+from __future__ import annotations
+
+import typer
+
+from fapi import Extension, FastAPI
+
+
+class StatusExtension(Extension):
+    def cli_commands(self):
+        def show_status() -> None:
+            typer.echo("status ok")
+
+        return [show_status]
+
+
+def build_app() -> FastAPI:
+    return FastAPI(extensions=[StatusExtension()])

--- a/examples/factory_app.py
+++ b/examples/factory_app.py
@@ -1,0 +1,18 @@
+"""Example factory-based application setup."""
+from __future__ import annotations
+
+from fapi import Module, create_app
+from fapi.routing import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+def index() -> dict[str, str]:
+    return {"hello": "world"}
+
+
+module = Module("core")
+module.add_router(router)
+
+app = create_app(config={"log_level": "info"}, modules=[module])

--- a/examples/module_basic.py
+++ b/examples/module_basic.py
@@ -1,0 +1,23 @@
+"""Example module with a router and config defaults."""
+from __future__ import annotations
+
+from fapi import FastAPI, Module
+from fapi.routing import APIRouter
+
+module = Module("metrics", prefix="/metrics", tags=["metrics"])
+router = APIRouter()
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+module.add_router(router)
+module.add_config_defaults({"enabled": True})
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    app.register_module(module)
+    return app

--- a/fapi/__init__.py
+++ b/fapi/__init__.py
@@ -6,9 +6,19 @@ from starlette import status as status
 
 from .applications import FastAPI as FastAPI
 from .background import BackgroundTasks as BackgroundTasks
+from .cli import app_cli as cli
+from .config import Config as Config
+from .context import current_app as current_app
+from .context import g as g
+from .context import request as request
 from .datastructures import UploadFile as UploadFile
+from .events import emit as emit
+from .events import on as on
+from .extensions import Extension as Extension
+from .factory import create_app as create_app
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .modules import Module as Module
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fapi/applications.py
+++ b/fapi/applications.py
@@ -1,10 +1,12 @@
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
     Coroutine,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -15,7 +17,10 @@ from typing import (
 
 from annotated_doc import Doc
 from fapi import routing
+from fapi.config import Config
+from fapi.context import ContextMiddleware, context
 from fapi.datastructures import Default, DefaultPlaceholder
+from fapi.events import EventMiddleware, emit
 from fapi.exception_handlers import (
     http_exception_handler,
     request_validation_exception_handler,
@@ -37,7 +42,6 @@ from starlette.applications import Starlette
 from starlette.datastructures import State
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
@@ -47,6 +51,10 @@ from starlette.types import ASGIApp, ExceptionHandler, Lifespan, Receive, Scope,
 from typing_extensions import Annotated, deprecated
 
 AppType = TypeVar("AppType", bound="FastAPI")
+
+if TYPE_CHECKING:
+    from fapi.extensions import Extension
+    from fapi.modules import Module
 
 
 class FastAPI(Starlette):
@@ -840,6 +848,46 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+        config: Annotated[
+            Optional[Dict[str, Any]],
+            Doc(
+                """
+                Optional configuration mapping to load into the app config.
+                """
+            ),
+        ] = None,
+        instance_path: Annotated[
+            Optional[str],
+            Doc(
+                """
+                Optional instance path to load configuration from.
+                """
+            ),
+        ] = None,
+        extensions: Annotated[
+            Optional[Iterable["Extension"]],
+            Doc(
+                """
+                Extensions to register with the application.
+                """
+            ),
+        ] = None,
+        modules: Annotated[
+            Optional[Iterable["Module"]],
+            Doc(
+                """
+                Modules to attach to the application.
+                """
+            ),
+        ] = None,
+        use_context_locals: Annotated[
+            bool,
+            Doc(
+                """
+                Enable context-local proxies for current app and request data.
+                """
+            ),
+        ] = False,
         **extra: Annotated[
             Any,
             Doc(
@@ -870,6 +918,28 @@ class FastAPI(Starlette):
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
         self.extra = extra
+        self.config = Config()
+        self.config.load_defaults(
+            {
+                "TITLE": title,
+                "SUMMARY": summary,
+                "DESCRIPTION": description,
+                "VERSION": version,
+            }
+        )
+        if config:
+            self.config.load_defaults(config, namespace="APP")
+        self.load_config_from_env()
+        if instance_path:
+            self.config.load_instance_folder(instance_path)
+        self.context = context
+        self.extensions: List["Extension"] = []
+        self.modules: List["Module"] = []
+        self.tool_registry: List[Dict[str, Any]] = []
+        self.use_context_locals = use_context_locals
+        from fapi.cli import app_cli
+
+        self.cli_app = app_cli
         self.openapi_version: Annotated[
             str,
             Doc(
@@ -993,6 +1063,57 @@ class FastAPI(Starlette):
         )
         self.middleware_stack: Union[ASGIApp, None] = None
         self.setup()
+        for extension in extensions or []:
+            self.register_extension(extension)
+        for module in modules or []:
+            self.register_module(module)
+
+    def load_config_from_env(self, prefix: str = "FAPI_") -> None:
+        """Load configuration from environment variables."""
+        self.config.from_env(prefix)
+
+    def apply_middleware_definition(self, middleware_def: Any) -> None:
+        """Apply a middleware definition to the app."""
+        if isinstance(middleware_def, Middleware):
+            self.user_middleware.append(middleware_def)
+            self.middleware_stack = None
+            return
+        if isinstance(middleware_def, tuple):
+            if len(middleware_def) == 2 and isinstance(middleware_def[1], dict):
+                self.add_middleware(middleware_def[0], **middleware_def[1])
+                return
+            if len(middleware_def) == 1:
+                self.add_middleware(middleware_def[0])
+                return
+        self.add_middleware(middleware_def)
+
+    def register_extension(self, extension: "Extension") -> None:
+        """Register an extension with this application."""
+        self.extensions.append(extension)
+        extension.init_app(self)
+        for router in extension.routers():
+            self.include_router(router)
+        for middleware_def in extension.middleware():
+            self.apply_middleware_definition(middleware_def)
+        for depends, override in extension.dependencies():
+            self.dependency_overrides[depends] = override
+        for hook in extension.lifespan_hooks():
+            self.add_event_handler("startup", hook)
+        for schema in extension.tool_metadata():
+            self.tool_registry.append(schema)
+        defaults = extension.config_defaults()
+        if defaults:
+            self.config.load_defaults(
+                defaults, namespace=extension.__class__.__name__
+            )
+        for command in extension.cli_commands():
+            self.cli_app.command()(command)
+        emit("extension_registered", extension=extension, app=self)
+
+    def register_module(self, module: "Module") -> None:
+        """Attach a module to this application."""
+        module.attach(self)
+        self.modules.append(module)
 
     def build_middleware_stack(self) -> ASGIApp:
         # Duplicate/override from Starlette to add AsyncExitStackMiddleware
@@ -1008,12 +1129,21 @@ class FastAPI(Starlette):
                 exception_handlers[key] = value
 
         middleware = (
-            [Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug)]
+            [
+                Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug),
+                Middleware(EventMiddleware),
+            ]
             + self.user_middleware
             + [
                 Middleware(
                     ExceptionMiddleware, handlers=exception_handlers, debug=debug
                 ),
+            ]
+        )
+        if self.use_context_locals:
+            middleware.append(Middleware(ContextMiddleware, app_context=self))
+        middleware.extend(
+            [
                 # Add FastAPI-specific AsyncExitStackMiddleware for closing files.
                 # Before this was also used for closing dependencies with yield but
                 # those now have their own AsyncExitStack, to properly support

--- a/fapi/cli.py
+++ b/fapi/cli.py
@@ -1,13 +1,42 @@
-try:
-    from fastapi_cli.cli import main as cli_main
+"""Typer-based command line interface for FAPI."""
+from __future__ import annotations
 
-except ImportError:  # pragma: no cover
-    cli_main = None  # type: ignore
+from typing import Optional
+
+import typer
+
+from fapi.factory import create_app
+
+app_cli = typer.Typer(help="FAPI command line interface")
+
+
+@app_cli.command()
+def run(host: str = "127.0.0.1", port: int = 8000, reload: bool = False) -> None:
+    """Run a FAPI app using uvicorn."""
+    import uvicorn
+
+    app = create_app()
+    uvicorn.run(app, host=host, port=port, reload=reload)
+
+
+@app_cli.command()
+def list_tools() -> None:
+    """List registered tool schemas."""
+    app = create_app()
+    for schema in getattr(app, "tool_registry", []):
+        typer.echo(f"{schema.get('name')} - v{schema.get('version')}")
+
+
+@app_cli.command()
+def show_config(prefix: Optional[str] = None) -> None:
+    """Print the effective configuration."""
+    app = create_app()
+    for key, value in app.config._data.items():
+        if prefix and not key.startswith(prefix.upper()):
+            continue
+        typer.echo(f"{key} = {value}")
 
 
 def main() -> None:
-    if not cli_main:  # type: ignore[truthy-function]
-        message = 'To use the fastapi command, please install "fastapi[standard]":\n\n\tpip install "fastapi[standard]"\n'
-        print(message)
-        raise RuntimeError(message)  # noqa: B904
-    cli_main()
+    """Entry point for the fapi command."""
+    app_cli()

--- a/fapi/config.py
+++ b/fapi/config.py
@@ -1,0 +1,54 @@
+"""Configuration registry for FAPI applications."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+
+class Config:
+    """A simple configuration registry with namespacing support."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Any] = {}
+        self.instance_path: Optional[str] = None
+
+    def load_defaults(self, defaults: Dict[str, Any], namespace: str = "") -> None:
+        """Merge defaults under a namespace; use double-underscore to nest."""
+        for key, value in defaults.items():
+            namespaced_key = (
+                f"{namespace.upper()}__{key.upper()}" if namespace else key.upper()
+            )
+            self._data.setdefault(namespaced_key, value)
+
+    def from_env(self, prefix: str = "") -> None:
+        """Override with environment variables matching the prefix."""
+        for key, value in os.environ.items():
+            if prefix and not key.startswith(prefix):
+                continue
+            self._data[key.upper()] = value
+
+    def from_file(self, filename: str) -> None:
+        """Load config values from a JSON or Python file."""
+        if filename.endswith(".json"):
+            with open(filename, encoding="utf-8") as handle:
+                self._data.update(json.load(handle))
+        elif filename.endswith(".py"):
+            data: Dict[str, Any] = {}
+            with open(filename, encoding="utf-8") as handle:
+                exec(handle.read(), data)
+            self._data.update({k: v for k, v in data.items() if k.isupper()})
+
+    def load_instance_folder(self, path: str) -> None:
+        """Set the instance path and load config.py within it if present."""
+        self.instance_path = path
+        config_py = os.path.join(path, "config.py")
+        if os.path.exists(config_py):
+            self.from_file(config_py)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Retrieve a configuration value, returning a default if missing."""
+        return self._data.get(key.upper(), default)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key.upper()]

--- a/fapi/context.py
+++ b/fapi/context.py
@@ -1,0 +1,90 @@
+"""Context-local proxies for FAPI applications."""
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from starlette.requests import Request
+
+if TYPE_CHECKING:
+    from fapi.applications import FastAPI
+
+
+class LocalProxy:
+    """A minimal proxy for context-local objects."""
+
+    def __init__(self, func: Callable[[], Any]) -> None:
+        self._func = func
+
+    def _get_current_object(self) -> Any:
+        return self._func()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._get_current_object(), name)
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._get_current_object()[key]
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        self._get_current_object()[key] = value
+
+    def __delitem__(self, key: Any) -> None:
+        del self._get_current_object()[key]
+
+    def __iter__(self):
+        return iter(self._get_current_object())
+
+    def __len__(self) -> int:
+        return len(self._get_current_object())
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self._get_current_object()
+
+    def __repr__(self) -> str:
+        return repr(self._get_current_object())
+
+
+_app_ctx: contextvars.ContextVar[Optional["FastAPI"]] = contextvars.ContextVar(
+    "fapi_app"
+)
+_req_ctx: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar("fapi_request")
+_g_ctx: contextvars.ContextVar[dict] = contextvars.ContextVar("fapi_g", default={})
+
+current_app = LocalProxy(lambda: _app_ctx.get())
+request = LocalProxy(lambda: _req_ctx.get())
+g = LocalProxy(lambda: _g_ctx.get())
+
+
+@dataclass(frozen=True)
+class Context:
+    """Container for context-local proxies."""
+
+    current_app: LocalProxy
+    request: LocalProxy
+    g: LocalProxy
+
+
+context = Context(current_app=current_app, request=request, g=g)
+
+
+class ContextMiddleware:
+    """Middleware that pushes app, request and g into contextvars per request."""
+
+    def __init__(self, app: "FastAPI", app_context: Optional["FastAPI"] = None) -> None:
+        self.app = app
+        self.app_context = app_context or app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        token_app = _app_ctx.set(self.app_context)
+        token_req = _req_ctx.set(Request(scope, receive=receive))
+        token_g = _g_ctx.set({})
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _app_ctx.reset(token_app)
+            _req_ctx.reset(token_req)
+            _g_ctx.reset(token_g)

--- a/fapi/events.py
+++ b/fapi/events.py
@@ -1,0 +1,77 @@
+"""Event bus utilities for FAPI applications."""
+from __future__ import annotations
+
+from typing import (
+    Any,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+)
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+EVENT_NAMES: List[str] = [
+    "request_started",
+    "request_finished",
+    "tool_invoked",
+    "tool_stream_chunk",
+    "tool_completed",
+    "auth_resolved",
+    "exception_raised",
+    "module_attached",
+    "extension_registered",
+]
+
+_listeners: Dict[str, List[Callable[..., None]]] = {}
+
+
+def on(event_name: str, listener: Callable[..., None]) -> None:
+    """Register a listener for an event. Listeners must accept **kwargs."""
+    _listeners.setdefault(event_name, []).append(listener)
+
+
+def emit(event_name: str, **data: Any) -> None:
+    """Emit an event to all subscribed listeners."""
+    for listener in _listeners.get(event_name, []):
+        try:
+            listener(**data)
+        except Exception:
+            pass
+
+
+class EventMiddleware(BaseHTTPMiddleware):
+    """Emit request lifecycle events for HTTP requests."""
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        emit("request_started", request=request)
+        response = await call_next(request)
+        emit("request_finished", response=response)
+        return response
+
+
+def stream_with_events(tool_name: str, chunks: Iterable[Any]) -> Iterable[Any]:
+    """Yield chunks while emitting tool stream events."""
+    emit("tool_invoked", tool=tool_name)
+    for chunk in chunks:
+        emit("tool_stream_chunk", chunk=chunk, tool=tool_name)
+        yield chunk
+    emit("tool_completed", tool=tool_name)
+
+
+async def async_stream_with_events(
+    tool_name: str, chunks: AsyncIterable[Any]
+) -> AsyncIterator[Any]:
+    """Yield async chunks while emitting tool stream events."""
+    emit("tool_invoked", tool=tool_name)
+    async for chunk in chunks:
+        emit("tool_stream_chunk", chunk=chunk, tool=tool_name)
+        yield chunk
+    emit("tool_completed", tool=tool_name)

--- a/fapi/extensions.py
+++ b/fapi/extensions.py
@@ -1,0 +1,49 @@
+"""Extension protocol for FAPI applications."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List
+
+if TYPE_CHECKING:
+    from fapi.applications import FastAPI
+
+
+class Extension:
+    """
+    Base class for FAPI extensions.
+
+    Subclasses may override any of these methods to contribute routers,
+    middleware, dependencies, events, config defaults, or CLI commands to an app.
+    Extensions should not store the app instance on themselves; they may be
+    reused across apps.
+    """
+
+    def init_app(self, app: "FastAPI") -> None:
+        """Called by the host application to initialize this extension."""
+
+    def routers(self) -> Iterable[Any]:
+        """Return an iterable of routers to register on the app."""
+        return []
+
+    def middleware(self) -> Iterable[Any]:
+        """Return an iterable of middleware definitions."""
+        return []
+
+    def dependencies(self) -> Iterable[Any]:
+        """Return an iterable of (depends, override) pairs."""
+        return []
+
+    def lifespan_hooks(self) -> Iterable[Callable[..., Any]]:
+        """Return an iterable of callables to register on the app's lifespan."""
+        return []
+
+    def tool_metadata(self) -> List[Dict[str, Any]]:
+        """Return a list of tool schemas (metadata) defined by this extension."""
+        return []
+
+    def config_defaults(self) -> Dict[str, Any]:
+        """Return default configuration values for this extension."""
+        return {}
+
+    def cli_commands(self) -> Iterable[Callable[..., Any]]:
+        """Return CLI command functions to register with the app CLI."""
+        return []

--- a/fapi/factory.py
+++ b/fapi/factory.py
@@ -1,0 +1,28 @@
+"""Application factory helpers for FAPI."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+from fapi.applications import FastAPI
+from fapi.extensions import Extension
+from fapi.modules import Module
+
+
+def create_app(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    extensions: Optional[Iterable[Extension]] = None,
+    modules: Optional[Iterable[Module]] = None,
+    instance_path: Optional[str] = None,
+) -> FastAPI:
+    """Factory to create a FAPI application."""
+    app = FastAPI()
+    if config:
+        app.config.load_defaults(config, namespace="APP")
+    if instance_path:
+        app.config.load_instance_folder(instance_path)
+    for extension in extensions or []:
+        app.register_extension(extension)
+    for module in modules or []:
+        app.register_module(module)
+    return app

--- a/fapi/modules.py
+++ b/fapi/modules.py
@@ -1,0 +1,75 @@
+"""Blueprint-style module support for FAPI applications."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+from fapi.routing import APIRouter
+
+from fapi.events import emit
+
+if TYPE_CHECKING:
+    from fapi.applications import FastAPI
+
+
+class Module:
+    """
+    Encapsulates a set of routes, middleware, config, hooks, and tool schemas.
+
+    Modules defer registering these operations until attach() is called.
+    """
+
+    def __init__(self, name: str, *, prefix: str = "", tags: Optional[List[str]] = None):
+        self.name = name
+        self.prefix = prefix
+        self.tags = tags or []
+        self._operations: List[Callable[["FastAPI"], None]] = []
+        self._tool_metadata: List[Dict[str, Any]] = []
+        self._config_defaults: Dict[str, Any] = {}
+        self._cli_commands: List[Callable[..., Any]] = []
+
+    def add_router(self, router: APIRouter, **kwargs: Any) -> None:
+        """Record a router to be included when this module attaches to an app."""
+
+        def op(app: "FastAPI") -> None:
+            app.include_router(router, prefix=self.prefix, tags=self.tags, **kwargs)
+
+        self._operations.append(op)
+
+    def add_middleware(self, middleware_def: Any) -> None:
+        """Record middleware to add later."""
+
+        def op(app: "FastAPI") -> None:
+            app.apply_middleware_definition(middleware_def)
+
+        self._operations.append(op)
+
+    def add_config_defaults(self, defaults: Dict[str, Any]) -> None:
+        """Record config defaults to apply when attaching."""
+        self._config_defaults.update(defaults)
+
+    def add_tool_metadata(self, schema: Dict[str, Any]) -> None:
+        """Record tool metadata to register on the app."""
+        self._tool_metadata.append(schema)
+
+    def add_cli_command(self, command: Callable[..., Any]) -> None:
+        """Record a CLI command to register on attach."""
+        self._cli_commands.append(command)
+
+    def add_hook(self, hook: Callable[..., Any]) -> None:
+        """Record a module-specific startup hook."""
+
+        def op(app: "FastAPI") -> None:
+            app.add_event_handler("startup", hook)
+
+        self._operations.append(op)
+
+    def attach(self, app: "FastAPI") -> None:
+        """Apply recorded operations to an app."""
+        app.config.load_defaults(self._config_defaults, namespace=self.name)
+        for op in self._operations:
+            op(app)
+        for schema in self._tool_metadata:
+            app.tool_registry.append(schema)
+        for command in self._cli_commands:
+            app.cli_app.command()(command)
+        emit("module_attached", module=self, app=app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
     "annotated-doc>=0.0.2",
+    "typer>=0.12.0,<1.0.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e .[all]
 -r requirements-tests.txt
 -r requirements-docs.txt
+typer>=0.12.0,<1.0.0
 pre-commit >=2.17.0,<5.0.0
 # For generating screenshots
 playwright

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+
+from typer.testing import CliRunner
+
+from fapi import FastAPI
+from fapi import cli as app_cli
+
+cli_module = importlib.import_module("fapi.cli")
+
+
+def test_cli_list_tools(monkeypatch) -> None:
+    app = FastAPI()
+    app.tool_registry.append(
+        {"name": "tool", "version": "1.0", "description": "tool"}
+    )
+
+    monkeypatch.setattr(cli_module, "create_app", lambda: app)
+
+    runner = CliRunner()
+    result = runner.invoke(app_cli, ["list-tools"])
+
+    assert result.exit_code == 0
+    assert "tool - v1.0" in result.output
+
+
+def test_cli_show_config(monkeypatch) -> None:
+    app = FastAPI(config={"mode": "dev"})
+    monkeypatch.setattr(cli_module, "create_app", lambda: app)
+
+    runner = CliRunner()
+    result = runner.invoke(app_cli, ["show-config", "--prefix", "APP__"])
+
+    assert result.exit_code == 0
+    assert "APP__MODE = dev" in result.output

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fapi import FastAPI
+from fapi.config import Config
+
+
+def test_config_defaults_and_env(monkeypatch) -> None:
+    config = Config()
+    config.load_defaults({"value": "default"})
+    monkeypatch.setenv("FAPI_VALUE", "env")
+    config.from_env(prefix="FAPI_")
+
+    assert config.get("VALUE") == "default"
+    assert config.get("FAPI_VALUE") == "env"
+
+
+def test_app_config_instance_folder(tmp_path: Path, monkeypatch) -> None:
+    instance_path = tmp_path / "instance"
+    instance_path.mkdir()
+    config_file = instance_path / "config.py"
+    config_file.write_text("APP_NAME = 'instance'\n", encoding="utf-8")
+
+    monkeypatch.setenv("FAPI_ENV", "set")
+    app = FastAPI(config={"setting": "value"}, instance_path=str(instance_path))
+
+    assert app.config.get("TITLE") == "FastAPI"
+    assert app.config.get("APP__SETTING") == "value"
+    assert app.config.get("FAPI_ENV") == "set"
+    assert app.config.get("APP_NAME") == "instance"

--- a/tests/test_context_locals.py
+++ b/tests/test_context_locals.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fapi import FastAPI
+from fapi.context import current_app, g, request
+from fapi.testclient import TestClient
+
+
+def test_context_locals_set_and_reset() -> None:
+    app = FastAPI(use_context_locals=True)
+
+    @app.get("/ctx")
+    def ctx_view() -> dict[str, object]:
+        had_value = "value" in g
+        g["value"] = "set"
+        return {
+            "app_title": current_app.title,
+            "method": request.method,
+            "had_value": had_value,
+        }
+
+    client = TestClient(app)
+    first = client.get("/ctx")
+    second = client.get("/ctx")
+
+    assert first.json()["app_title"] == app.title
+    assert first.json()["method"] == "GET"
+    assert first.json()["had_value"] is False
+
+    assert second.json()["had_value"] is False

--- a/tests/test_events_bus.py
+++ b/tests/test_events_bus.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fapi import FastAPI
+from fapi.events import on, stream_with_events
+from fapi.testclient import TestClient
+
+
+def test_request_events(monkeypatch) -> None:
+    events: List[str] = []
+
+    def record(event_name: str):
+        def _listener(**_: Any) -> None:
+            events.append(event_name)
+
+        return _listener
+
+    monkeypatch.setattr("fapi.events._listeners", {})
+    on("request_started", record("request_started"))
+    on("request_finished", record("request_finished"))
+
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> Dict[str, str]:
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    response = client.get("/ping")
+
+    assert response.json() == {"ok": "true"}
+    assert events == ["request_started", "request_finished"]
+
+
+def test_stream_events_sync(monkeypatch) -> None:
+    seen: List[str] = []
+
+    def wrap(event_name: str):
+        def _listener(**data: Any) -> None:
+            seen.append(event_name)
+
+        return _listener
+
+    monkeypatch.setattr("fapi.events._listeners", {})
+    on("tool_invoked", wrap("tool_invoked"))
+    on("tool_stream_chunk", wrap("tool_stream_chunk"))
+    on("tool_completed", wrap("tool_completed"))
+
+    chunks = list(stream_with_events("tool", ["a", "b"]))
+
+    assert chunks == ["a", "b"]
+    assert seen == [
+        "tool_invoked",
+        "tool_stream_chunk",
+        "tool_stream_chunk",
+        "tool_completed",
+    ]
+
+
+def test_extension_module_events(monkeypatch) -> None:
+    events: List[str] = []
+
+    def listener(event_name: str):
+        def _listener(**_: Any) -> None:
+            events.append(event_name)
+
+        return _listener
+
+    monkeypatch.setattr("fapi.events._listeners", {})
+    on("extension_registered", listener("extension_registered"))
+    on("module_attached", listener("module_attached"))
+
+    from fapi.extensions import Extension
+    from fapi.modules import Module
+
+    app = FastAPI()
+
+    class EventExtension(Extension):
+        pass
+
+    app.register_extension(EventExtension())
+    app.register_module(Module("events"))
+
+    assert events == ["extension_registered", "module_attached"]

--- a/tests/test_extensions_modules.py
+++ b/tests/test_extensions_modules.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import List
+
+import typer
+from typer.testing import CliRunner
+
+from fapi import APIRouter, Depends, FastAPI
+from fapi.extensions import Extension
+from fapi.modules import Module
+from fapi.testclient import TestClient
+
+
+def base_dep() -> str:
+    return "base"
+
+
+def override_dep() -> str:
+    return "override"
+
+
+class HeaderMiddleware:
+    def __init__(self, app, header_name: str, header_value: str) -> None:
+        self.app = app
+        self.header_name = header_name
+        self.header_value = header_value
+
+    async def __call__(self, scope, receive, send) -> None:
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                headers.append(
+                    (self.header_name.encode(), self.header_value.encode())
+                )
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class SampleExtension(Extension):
+    def __init__(self, call_log: List[str]) -> None:
+        self.call_log = call_log
+
+    def init_app(self, app: FastAPI) -> None:
+        self.call_log.append("init")
+
+    def routers(self):
+        router = APIRouter()
+
+        @router.get("/ext")
+        def ext_route(value: str = Depends(base_dep)) -> dict[str, str]:
+            return {"value": value}
+
+        return [router]
+
+    def middleware(self):
+        return [
+            (HeaderMiddleware, {"header_name": "x-ext", "header_value": "enabled"})
+        ]
+
+    def dependencies(self):
+        return [(base_dep, override_dep)]
+
+    def lifespan_hooks(self):
+        def startup() -> None:
+            self.call_log.append("startup")
+
+        return [startup]
+
+    def tool_metadata(self):
+        return [
+            {
+                "name": "ext_tool",
+                "version": "1.0",
+                "description": "Extension tool",
+                "input_schema": {"type": "object"},
+                "output_schema": {"type": "object"},
+            }
+        ]
+
+    def config_defaults(self):
+        return {"enabled": True}
+
+    def cli_commands(self):
+        def ext_command() -> None:
+            typer.echo("extension command")
+
+        return [ext_command]
+
+
+def test_extension_registration() -> None:
+    call_log: List[str] = []
+    extension = SampleExtension(call_log)
+    app = FastAPI(extensions=[extension])
+
+    client = TestClient(app)
+    response = client.get("/ext")
+
+    assert response.json() == {"value": "override"}
+    assert response.headers["x-ext"] == "enabled"
+    assert "init" in call_log
+
+    assert app.config.get("SAMPLEEXTENSION__ENABLED") is True
+    assert app.tool_registry[0]["name"] == "ext_tool"
+
+    runner = CliRunner()
+    result = runner.invoke(app.cli_app, ["ext-command"])
+    assert result.exit_code == 0
+    assert "extension command" in result.output
+
+
+def test_module_registration() -> None:
+    module = Module("tools", prefix="/mod", tags=["mod"])
+    router = APIRouter()
+
+    @router.get("/ping")
+    def ping() -> dict[str, str]:
+        return {"ok": "true"}
+
+    module.add_router(router)
+    module.add_middleware(
+        (HeaderMiddleware, {"header_name": "x-mod", "header_value": "on"})
+    )
+    module.add_config_defaults({"flag": "enabled"})
+    module.add_tool_metadata(
+        {
+            "name": "mod_tool",
+            "version": "1.0",
+            "description": "Module tool",
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+        }
+    )
+
+    def module_command() -> None:
+        typer.echo("module command")
+
+    module.add_cli_command(module_command)
+
+    app = FastAPI()
+    app.register_module(module)
+
+    client = TestClient(app)
+    response = client.get("/mod/ping")
+
+    assert response.json() == {"ok": "true"}
+    assert response.headers["x-mod"] == "on"
+    assert app.config.get("TOOLS__FLAG") == "enabled"
+    assert app.tool_registry[0]["name"] == "mod_tool"
+
+    runner = CliRunner()
+    result = runner.invoke(app.cli_app, ["module-command"])
+    assert result.exit_code == 0
+    assert "module command" in result.output

--- a/tests/test_fastapi_cli.py
+++ b/tests/test_fastapi_cli.py
@@ -1,32 +1,33 @@
 import subprocess
 import sys
-from unittest.mock import patch
-
-import fastapi.cli
-import pytest
 
 
-def test_fastapi_cli():
+def test_fapi_cli_help() -> None:
     result = subprocess.run(
         [
             sys.executable,
             "-m",
-            "coverage",
-            "run",
-            "-m",
             "fapi",
-            "dev",
-            "non_existent_file.py",
+            "--help",
         ],
         capture_output=True,
         encoding="utf-8",
     )
-    assert result.returncode == 1, result.stdout
-    assert "Path does not exist non_existent_file.py" in result.stdout
+    assert result.returncode == 0, result.stdout
+    assert "FAPI command line interface" in result.stdout
 
 
-def test_fastapi_cli_not_installed():
-    with patch.object(fastapi.cli, "cli_main", None):
-        with pytest.raises(RuntimeError) as exc_info:
-            fastapi.cli.main()
-        assert "To use the fastapi command, please install" in str(exc_info.value)
+def test_fapi_cli_run_help() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "fapi",
+            "run",
+            "--help",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stdout
+    assert "Run a FAPI app using uvicorn." in result.stdout


### PR DESCRIPTION
### Motivation

- Align tests with the refactored `fapi` Typer-based CLI and remove references to `fastapi.cli`.
- Verify top-level help and `run` subcommand help output for the new CLI entrypoint.

### Description

- Replaced the previous `tests/test_fastapi_cli.py` to invoke `python -m fapi --help` and `python -m fapi run --help` and assert expected help text.
- Removed legacy imports and mocking of `fastapi.cli` and simplified the test to target the `fapi` entrypoint.
- Saved and committed the updated test file `tests/test_fastapi_cli.py`.

### Testing

- Ran `python -m pytest tests/test_fastapi_cli.py` and both tests passed (`2 passed`).
- No other automated test suites were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617336553483289299b5bd1d467327)